### PR TITLE
feat: allow public access to claims bucket

### DIFF
--- a/stacks/bucket.js
+++ b/stacks/bucket.js
@@ -14,7 +14,7 @@ export function Bucket ({ stack }) {
           ignorePublicAcls: true,
           // allow public read access
           blockPublicPolicy: false,
-          restrictPublicBuckets: false,
+          restrictPublicBuckets: false
         }
       }
     }

--- a/stacks/bucket.js
+++ b/stacks/bucket.js
@@ -4,6 +4,20 @@ import { Bucket as S3Bucket } from 'sst/constructs'
  * @param {import('sst/constructs').StackContext} config
  */
 export function Bucket ({ stack }) {
-  const claimsBucket = new S3Bucket(stack, 'claims-v1')
+  const claimsBucket = new S3Bucket(stack, 'claims-v1', {
+    cors: true,
+    cdk: {
+      bucket: {
+        blockPublicAccess: {
+          // do not allow public write access
+          blockPublicAcls: true,
+          ignorePublicAcls: true,
+          // allow public read access
+          blockPublicPolicy: false,
+          restrictPublicBuckets: false,
+        }
+      }
+    }
+  })
   return { claimsBucket }
 }


### PR DESCRIPTION
Per the description here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html#access-control-block-public-access-options - this PR enables public read access to the bucket. It allows the indexing service to read claims by URL without any special handling for these legacy claims.